### PR TITLE
Make config update ingame if using mods like LethalConfig

### DIFF
--- a/src/LethalCompanyPatchedPlugin.cs
+++ b/src/LethalCompanyPatchedPlugin.cs
@@ -17,7 +17,7 @@ namespace OoLunar.LethalCompanyPatched
         internal static ManualLogSource StaticLogger = null!;
         internal static ConfigEntry<float> InstantSprint = null!;
         internal static ConfigEntry<float> Slipperiness = null!;
-        internal static ConfigEntry<bool> InstantJump = null!;
+        internal static ConfigEntry<float> JumpDelay = null!;
         internal static ConfigEntry<bool> ShowHudPercentages = null!;
         internal static ConfigEntry<bool> CrouchHold = null!;
 
@@ -29,10 +29,11 @@ namespace OoLunar.LethalCompanyPatched
 
             StaticLogger = Logger;
             CrouchHold = Config.Bind("General", "crouchHold", true, "Enable/disable crouch hold. If disabled, crouch functions as a toggle with the additional behavior of going back into a crouch upon landing from a crouch jump.");
-            InstantJump = Config.Bind("General", "instantJump", true, "Enable/disable instant jump. Removes the delay with jumping when enabled.");
-            InstantSprint = Config.Bind("General", "instantSprint", 2.25f, "How fast to accelerate to sprint value of 2.25. 2.25 is the max, so it's instant acceleration.");
-            Slipperiness = Config.Bind("General", "slipperiness", 10f, "The amount of slipperiness when running and changing direction. 10-15f is a good value for little to no slippery feeling.");
+            JumpDelay = Config.Bind("General", "jumpDelay", 0.0f, "Configure the time till jump, defaults to instant with 0.0. Vanilla is 0.15");
+            InstantSprint = Config.Bind("General", "instantSprint", 2.25f, "How fast to accelerate to sprint value of 2.25. 2.25 is the max, so it's instant acceleration. Vanilla is 1.0");
+            Slipperiness = Config.Bind("General", "slipperiness", 10f, "The amount of slipperiness when running and changing direction. 10-15f is a good value for little to no slippery feeling. Vanilla is 5.0");
             ShowHudPercentages = Config.Bind("General", "showHealthStamina", true, "Show your health and sprint/stamina % on the HUD.");
+            
             foreach (Type type in typeof(LethalCompanyPatchedPlugin).Assembly.GetTypes())
             {
                 // Find all types in this assembly that have the LethalPatchAttribute applied to them.
@@ -41,11 +42,8 @@ namespace OoLunar.LethalCompanyPatched
                     _harmony.PatchAll(type);
                 }
             }
-
-            if (ShowHudPercentages.Value)
-            {
-                _harmony.PatchAll(typeof(HUDManagerPatch));
-            }
+            _harmony.PatchAll(typeof(HUDManagerPatch));
+            
 
             Logger.LogInfo($"{MyPluginInfo.PLUGIN_NAME} finished loading!");
         }

--- a/src/Patches/HudManagerPatch.cs
+++ b/src/Patches/HudManagerPatch.cs
@@ -1,3 +1,5 @@
+using System;
+using GameNetcodeStuff;
 using HarmonyLib;
 using TMPro;
 using UnityEngine;
@@ -32,7 +34,7 @@ namespace OoLunar.LethalCompanyPatched.Patches
             _hudPercentagesText.fontSize = 12f;
             _hudPercentagesText.margin = new Vector4(0f, -36f, 100f, 0f);
             _hudPercentagesText.alignment = (TextAlignmentOptions)260;
-            _hudPercentagesText.text = $"{100}\n\n\n{100}%";
+            _hudPercentagesText.text = "";
             _instantiating = false;
         }
 
@@ -44,19 +46,20 @@ namespace OoLunar.LethalCompanyPatched.Patches
         [HarmonyPatch(typeof(HUDManager), "Update")]
         public static void Update()
         {
-            if (GameNetworkManager.Instance.localPlayerController == null || _instantiating || _hudPercentagesText == null)
+            PlayerControllerB player_controller = GameNetworkManager.Instance.localPlayerController;
+            if (player_controller == null 
+                || _instantiating 
+                || _hudPercentagesText == null)
             {
                 return;
             }
-
-            float health = Mathf.RoundToInt(GameNetworkManager.Instance.localPlayerController.health);
-            float sprint = Mathf.RoundToInt(((GameNetworkManager.Instance.localPlayerController.sprintMeter * 100f) - 10f) / 90f * 100f);
-            if (sprint < 0f)
-            {
-                sprint = 0f;
-            }
-
-            _hudPercentagesText.text = $"{health}\n\n\n\n{sprint}%";
+            float health = Mathf.RoundToInt(player_controller.health);
+            int sprint = Math.Max(
+                Mathf.RoundToInt(((player_controller.sprintMeter * 100f) - 10f) / 90f * 100f), 
+                0
+                );
+            _hudPercentagesText.text = LethalCompanyPatchedPlugin.ShowHudPercentages.Value ? $"{health}\n\n\n\n{sprint}%" : "";
+           
         }
     }
 }


### PR DESCRIPTION
Changing a config option for this mod with mods like Lethal Config will reflect their changes in-game without the need for a restart.

There are also a bunch of other little changes I forgot to separate into separate commits:
Changing the type of InstantJump to a float for better configuration
Including the vanilla values in the config descriptions
Doing something to the CanJump function because it wouldn't compile otherwise
arbitrary Intellisense suggestions